### PR TITLE
Add a content field.

### DIFF
--- a/ftw/htmlblock/browser/htmlblock.py
+++ b/ftw/htmlblock/browser/htmlblock.py
@@ -1,6 +1,10 @@
 from ftw.simplelayout.browser.blocks.base import BaseBlock
+from plone import api
 
 
 class HtmlBlockView(BaseBlock):
     def __call__(self):
         return self.index()
+
+    def can_add(self):
+        return api.user.has_permission('ftw.htmlblock: Add HTML block')

--- a/ftw/htmlblock/browser/templates/htmlblock.pt
+++ b/ftw/htmlblock/browser/templates/htmlblock.pt
@@ -3,7 +3,13 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.htmlblock">
 
-    <h2 tal:content="here/Title" tal:condition="here/show_title " />
-    <p>TODO: Replace this static placeholder.</p>
+    <h2 tal:condition="view/block_title"
+        tal:content="view/block_title" />
+
+    <tal:content tal:condition=" context/content"
+                 tal:replace="structure  context/content"/>
+
+    <div tal:condition="python: view.can_add() and not context.content"
+         i18n:translate="empty_htmlblock_label">This HTML block is empty. Please add some content or remove the block.</div>
 
 </html>

--- a/ftw/htmlblock/configure.zcml
+++ b/ftw/htmlblock/configure.zcml
@@ -14,7 +14,7 @@
 
     <genericsetup:registerProfile
         name="default"
-        title="ftw.htmlblock default"
+        title="ftw.htmlblock"
         directory="profiles/default"
         description="HTML block (add-on for ftw.simplelayout)"
         provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/ftw/htmlblock/contents/htmlblock.py
+++ b/ftw/htmlblock/contents/htmlblock.py
@@ -23,6 +23,14 @@ class IHtmlBlockSchema(form.Schema):
         required=False,
     )
 
+    content = schema.Text(
+        title=_(u'htmlblock_content_label', default=u'Content'),
+        description=_(u'htmlblock_content_description',
+                      default=u'The content will be rendered without '
+                              u'being escaped.'),
+        required=False,
+    )
+
     form.order_before(title='*')
 
 alsoProvides(IHtmlBlockSchema, IFormFieldProvider)

--- a/ftw/htmlblock/lawgiver.zcml
+++ b/ftw/htmlblock/lawgiver.zcml
@@ -7,7 +7,7 @@
 
     <lawgiver:map_permissions
         action_group="add HTML blocks"
-        permissions="ftw.htmlblock: Add HtmlBlock"
+        permissions="ftw.htmlblock: Add HTML block"
         />
 
 </configure>

--- a/ftw/htmlblock/locales/de/LC_MESSAGES/ftw.htmlblock.po
+++ b/ftw/htmlblock/locales/de/LC_MESSAGES/ftw.htmlblock.po
@@ -26,9 +26,24 @@ msgstr "HTML-Block (Erweiterung für ftw.simplelayout)"
 msgid "The HTML block renders HTML without escaping it."
 msgstr "Der Inhalt dieses Blocks wird unverändert auf der Webseite ausgegeben."
 
+#. Default: "This HTML block is empty. Please add some content or remove the block."
+#: ./ftw/htmlblock/browser/templates/htmlblock.pt:12
+msgid "empty_htmlblock_label"
+msgstr "Dieser HTML-Block ist leer. Bitte Inhalt hinzufügen oder Block entfernen."
+
 #: ./ftw/htmlblock/configure.zcml:21
 msgid "ftw.htmlblock"
 msgstr ""
+
+#. Default: "The content will be rendered without being escaped."
+#: ./ftw/htmlblock/contents/htmlblock.py:28
+msgid "htmlblock_content_description"
+msgstr "Der Inhalt dieses Feldes wird unverändert auf der Webseite ausgegeben."
+
+#. Default: "Content"
+#: ./ftw/htmlblock/contents/htmlblock.py:27
+msgid "htmlblock_content_label"
+msgstr "Inhalt (HTML)"
 
 #. Default: "Show title"
 #: ./ftw/htmlblock/contents/htmlblock.py:21

--- a/ftw/htmlblock/locales/de/LC_MESSAGES/ftw.htmlblock.po
+++ b/ftw/htmlblock/locales/de/LC_MESSAGES/ftw.htmlblock.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-07 12:09+0000\n"
+"POT-Creation-Date: 2016-04-07 13:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgid "The HTML block renders HTML without escaping it."
 msgstr "Der Inhalt dieses Blocks wird unverändert auf der Webseite ausgegeben."
 
 #: ./ftw/htmlblock/configure.zcml:21
-msgid "ftw.htmlblock default"
+msgid "ftw.htmlblock"
 msgstr ""
 
 #. Default: "Show title"

--- a/ftw/htmlblock/locales/en/LC_MESSAGES/ftw.htmlblock.po
+++ b/ftw/htmlblock/locales/en/LC_MESSAGES/ftw.htmlblock.po
@@ -26,8 +26,23 @@ msgstr ""
 msgid "The HTML block renders HTML without escaping it."
 msgstr ""
 
+#. Default: "This HTML block is empty. Please add some content or remove the block."
+#: ./ftw/htmlblock/browser/templates/htmlblock.pt:12
+msgid "empty_htmlblock_label"
+msgstr ""
+
 #: ./ftw/htmlblock/configure.zcml:21
 msgid "ftw.htmlblock"
+msgstr ""
+
+#. Default: "The content will be rendered without being escaped."
+#: ./ftw/htmlblock/contents/htmlblock.py:28
+msgid "htmlblock_content_description"
+msgstr ""
+
+#. Default: "Content"
+#: ./ftw/htmlblock/contents/htmlblock.py:27
+msgid "htmlblock_content_label"
 msgstr ""
 
 #. Default: "Show title"

--- a/ftw/htmlblock/locales/en/LC_MESSAGES/ftw.htmlblock.po
+++ b/ftw/htmlblock/locales/en/LC_MESSAGES/ftw.htmlblock.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-07 12:09+0000\n"
+"POT-Creation-Date: 2016-04-07 13:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgid "The HTML block renders HTML without escaping it."
 msgstr ""
 
 #: ./ftw/htmlblock/configure.zcml:21
-msgid "ftw.htmlblock default"
+msgid "ftw.htmlblock"
 msgstr ""
 
 #. Default: "Show title"

--- a/ftw/htmlblock/locales/ftw.htmlblock.pot
+++ b/ftw/htmlblock/locales/ftw.htmlblock.pot
@@ -26,8 +26,23 @@ msgstr ""
 msgid "The HTML block renders HTML without escaping it."
 msgstr ""
 
+#. Default: "This HTML block is empty. Please add some content or remove the block."
+#: ./ftw/htmlblock/browser/templates/htmlblock.pt:12
+msgid "empty_htmlblock_label"
+msgstr ""
+
 #: ./ftw/htmlblock/configure.zcml:21
 msgid "ftw.htmlblock"
+msgstr ""
+
+#. Default: "The content will be rendered without being escaped."
+#: ./ftw/htmlblock/contents/htmlblock.py:28
+msgid "htmlblock_content_description"
+msgstr ""
+
+#. Default: "Content"
+#: ./ftw/htmlblock/contents/htmlblock.py:27
+msgid "htmlblock_content_label"
 msgstr ""
 
 #. Default: "Show title"

--- a/ftw/htmlblock/locales/ftw.htmlblock.pot
+++ b/ftw/htmlblock/locales/ftw.htmlblock.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-07 12:09+0000\n"
+"POT-Creation-Date: 2016-04-07 13:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgid "The HTML block renders HTML without escaping it."
 msgstr ""
 
 #: ./ftw/htmlblock/configure.zcml:21
-msgid "ftw.htmlblock default"
+msgid "ftw.htmlblock"
 msgstr ""
 
 #. Default: "Show title"

--- a/ftw/htmlblock/tests/test_content_type.py
+++ b/ftw/htmlblock/tests/test_content_type.py
@@ -17,13 +17,16 @@ class TestHtmlBlockContentType(FunctionalTestCase):
 
         browser.login().visit(content_page)
         factoriesmenu.add('HTML block')
-        browser.fill({'Title': u'Title of the HTML block'})
+        browser.fill({
+            'Title': u'Title of the HTML block',
+            'Content': u'<p>The content of the HTML block.</p>',
+        })
 
         browser.find_button_by_label('Save').click()
         browser.visit(content_page)
 
         self.assertTrue(len(browser.css('.sl-block')), 'Expect one block')
         self.assertEqual(
-            ['TODO: Replace this static placeholder.'],
+            ['The content of the HTML block.'],
             browser.css('div.ftw-htmlblock-htmlblock .sl-block-content').text
         )

--- a/ftw/htmlblock/tests/test_htmlblock.py
+++ b/ftw/htmlblock/tests/test_htmlblock.py
@@ -20,6 +20,7 @@ class TestHtmlBlock(FunctionalTestCase):
 
         create(Builder('html block')
                .titled(u'Title of the HTML block')
+               .having(content=u'<p>The main content of the HTML block.</p>')
                .within(content_page))
 
         browser.login().visit(content_page)
@@ -29,7 +30,7 @@ class TestHtmlBlock(FunctionalTestCase):
             browser.css('div.ftw-htmlblock-htmlblock .sl-block-content h2')
         )
         self.assertEqual(
-            ['TODO: Replace this static placeholder.'],
+            ['The main content of the HTML block.'],
             browser.css('div.ftw-htmlblock-htmlblock .sl-block-content').text
         )
 
@@ -44,6 +45,7 @@ class TestHtmlBlock(FunctionalTestCase):
         create(Builder('html block')
                .titled(u'Title of the HTML block')
                .having(show_title=True)
+               .having(content=u'<p>The content is not important in this test.</p>')
                .within(content_page))
 
         browser.login().visit(content_page)
@@ -51,4 +53,75 @@ class TestHtmlBlock(FunctionalTestCase):
         self.assertEqual(
             ['Title of the HTML block'],
             browser.css('div.ftw-htmlblock-htmlblock .sl-block-content h2').text
+        )
+
+    @browsing
+    def test_block_renders_hint_if_empty(self, browser):
+        """
+        This test makes sure that users having the permission to add HTML
+        block can see a warning if the block has no content.
+        """
+        content_page = create(Builder('sl content page'))
+
+        create(Builder('html block')
+               .titled(u'The title of the block is irrelevant in this test.')
+               .having(show_title=False)
+               .having(content=u'')
+               .within(content_page))
+
+        browser.login().visit(content_page)
+        self.assertEqual(
+            ['This HTML block is empty. Please add some content or remove the block.'],
+            browser.css('div.ftw-htmlblock-htmlblock .sl-block-content').text
+        )
+
+        # An anonymous user must not see the hint.
+        browser.logout().visit(content_page)
+        self.assertEqual(
+            [''],
+            browser.css('div.ftw-htmlblock-htmlblock .sl-block-content').text
+        )
+
+    @browsing
+    def test_script_tag_is_not_escaped(self, browser):
+        """
+        This test makes sure that even script tags are rendered without
+        being esacaped.
+        """
+        content_page = create(Builder('sl content page'))
+
+        script_tag = u'<script type="text/javascript">alert("Hello World!");</script>'
+
+        create(Builder('html block')
+               .titled(u'The title of the block is irrelevant in this test.')
+               .having(show_title=False)
+               .having(content=script_tag)
+               .within(content_page))
+
+        browser.login().visit(content_page)
+        self.assertEqual(
+            script_tag,
+            browser.css('div.ftw-htmlblock-htmlblock .sl-block-content').first.normalized_innerHTML
+        )
+
+    @browsing
+    def test_iframe_tag_is_not_escaped(self, browser):
+        """
+        This test makes sure that even iframe tags are rendered without
+        being esacaped.
+        """
+        content_page = create(Builder('sl content page'))
+
+        iframe_tag = u'<iframe src="http://www.w3schools.com"></iframe>'
+
+        create(Builder('html block')
+               .titled(u'The title of the block is irrelevant in this test.')
+               .having(show_title=False)
+               .having(content=iframe_tag)
+               .within(content_page))
+
+        browser.login().visit(content_page)
+        self.assertEqual(
+            iframe_tag,
+            browser.css('div.ftw-htmlblock-htmlblock .sl-block-content').first.normalized_innerHTML
         )

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     install_requires=[
         'ftw.simplelayout [contenttypes]',
         'setuptools',
+        'plone.api>=1.3.0',
         'plone.dexterity',
         'plone.app.dexterity',
         'Plone',


### PR DESCRIPTION
This is the field which takes arbitrary content, even HTML, and renders it without escaping it.
