### PR TITLE
Configure Plone properties.

### DIFF
--- a/ftw/htmlblock/profiles/default/propertiestool.xml
+++ b/ftw/htmlblock/profiles/default/propertiestool.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="navtree_properties" meta_type="Plone Property Sheet">
+        <property name="metaTypesNotToList" type="lines" purge="False">
+            <element value="ftw.htmlblock.HtmlBlock"/>
+        </property>
+    </object>
+
+    <object name="site_properties" meta_type="Plone Property Sheet">
+        <property name="types_not_searched" type="lines" purge="False">
+            <element value="ftw.htmlblock.HtmlBlock"/>
+        </property>
+    </object>
+
+</object>


### PR DESCRIPTION
Blocks should normally not be searchable or shown in the navigation.
