### PR TITLE
Prevent iframe from stopping event bubbling in IE.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Prevent iframe from stopping event bubbling in IE
+  [Kevin Bieri]
 
 1.0.0 (2016-05-20)
 ------------------

--- a/ftw/htmlblock/browser/resources/styles.scss
+++ b/ftw/htmlblock/browser/resources/styles.scss
@@ -1,1 +1,15 @@
 @include portal-type-font-awesome-icon(ftw-htmlblock-htmlblock, code);
+
+.sl-can-edit .ftw-htmlblock-htmlblock {
+  .sl-block-content {
+    @include ie-only() {
+      cursor: not-allowed;
+    }
+  }
+
+  iframe {
+    @include ie-only() {
+      pointer-events: none;
+    }
+  }
+}


### PR DESCRIPTION
⚠️  Depends on https://github.com/4teamwork/ftw.theming/pull/51, https://github.com/4teamwork/ftw.simplelayout/pull/335

Closes https://github.com/4teamwork/bl.web/issues/169

In IE it is not possible to track events on wrapping elements
containing an iframe.

ℹ️ According to http://caniuse.com/#feat=pointer-events this is only working on IE > 9.

<img width="392" alt="bildschirmfoto 2016-05-20 um 14 46 35" src="https://cloud.githubusercontent.com/assets/1637820/15428196/32b01710-1e9a-11e6-9a0c-fdf40a1e6c55.png">
