### PR TITLE
Remove metadata.xml-dependencie to ftw.simplelayout.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@
 Introduction
 ============
 
+*This package is an addon for `ftw.simplelayout <http://github.com/4teamwork/ftw.simplelayout>`_. Please make sure you
+already installed `ftw.simplelayout` on your plone site before installing this addon.*
+
 HTML blocks allow you to add arbitrary, unfiltered HTML to a content page.
 
 The HTML is not escaped when rendered on the content page so you need to be

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,12 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Remove metadata.xml-dependencie to ftw.simplelayout.
+  This package is an addon of ftw.simplelayout and should not install it.
+  [elioschmutz]
+
 - Add suport for iframe tags on MS Edge
-  [raphael-s] 
+  [raphael-s]
 
 
 1.0.1 (2016-05-24)

--- a/ftw/htmlblock/profiles/default/metadata.xml
+++ b/ftw/htmlblock/profiles/default/metadata.xml
@@ -2,6 +2,5 @@
 <metadata>
     <version>1000</version>
     <dependencies>
-        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/htmlblock/testing.py
+++ b/ftw/htmlblock/testing.py
@@ -26,6 +26,7 @@ class FtwHtmlBlockLayer(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         # Install into Plone site using portal_setup
+        applyProfile(portal, 'ftw.simplelayout.contenttypes:default')
         applyProfile(portal, 'ftw.htmlblock:default')
 
 


### PR DESCRIPTION
This package is an addon of ftw.simplelayout and should not install it.
