### PR TITLE
Enlarge input-field for html content

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enlarge textarea for html-block content.
+  [raphael-s]
 
 
 1.0.3 (2016-08-18)

--- a/ftw/htmlblock/browser/resources/styles.scss
+++ b/ftw/htmlblock/browser/resources/styles.scss
@@ -9,3 +9,7 @@
 @include ie-only(".sl-can-edit .ftw-htmlblock-htmlblock iframe") {
   pointer-events: none;
 }
+
+textarea#form-widgets-content {
+    min-height: 12em;
+}


### PR DESCRIPTION
Enlarges the input field of a HTML block so it displays a few more lines of text by default. This is mainly useful for smaller screens.

![bildschirmfoto 2016-09-12 um 17 25 50](https://cloud.githubusercontent.com/assets/16755391/18441609/fb121a82-790d-11e6-8731-11ce148ad624.png)

See: https://github.com/4teamwork/ftw.simplelayout/issues/376#event-778310661
