### PR TITLE
Make HtmlBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make HtmlBlock addable on plone site per default [raphael-s]
 
 
 1.0.4 (2016-09-12)

--- a/ftw/htmlblock/profiles/default/types/Plone_Site.xml
+++ b/ftw/htmlblock/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.htmlblock.HtmlBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.htmlblock` is installed the HtmlBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the HtmlBlock.