### PR TITLE
Define template in view, not in zcml.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+- Define template in view, not in zcml. [jone]
+
 - Add macros and slots to block views for easy customization. [jone]
 
 - Make iframe fixes compatible with ftw.iframefix 2.0. [Kevin Bieri]

--- a/ftw/htmlblock/browser/configure.zcml
+++ b/ftw/htmlblock/browser/configure.zcml
@@ -12,7 +12,6 @@
         name="block_view"
         permission="zope2.View"
         class=".htmlblock.HtmlBlockView"
-        template="templates/htmlblock.pt"
         />
 
 </configure>

--- a/ftw/htmlblock/browser/htmlblock.py
+++ b/ftw/htmlblock/browser/htmlblock.py
@@ -1,10 +1,10 @@
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from plone import api
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class HtmlBlockView(BaseBlock):
-    def __call__(self):
-        return self.index()
+    template = ViewPageTemplateFile('templates/htmlblock.pt')
 
     def can_add(self):
         return api.user.has_permission('ftw.htmlblock: Add HTML block')


### PR DESCRIPTION
ftw.simplelayout defines the template of the block views as view page tempalte file, not in ZCML. Let's be consistent and do it the same way. This makes generic customizations easier.